### PR TITLE
Update Dockerfile to buster instead of stable

### DIFF
--- a/pebble-sdk/Dockerfile
+++ b/pebble-sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:buster
 
 # update system and get base packages
 RUN apt-get update && \


### PR DESCRIPTION
Avoid future problems if the next version of stable doesn't play nice