### PR TITLE
Allow docker to output emulator to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Run the image
 
     docker run --name=RebbleSDK -it rebble/pebble-sdk
 
+### Emulator
+
+In order to use the emulator, Docker must know the display to output to.
+We can proxy the display by setting environment variables and bind mounts.
+
+    docker run --name=RebbleSDK -it \
+        -e DISPLAY=$DISPLAY \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        rebble/pebble-sdk


### PR DESCRIPTION
Just adding these few lines allow the emulator to appear.

Found from: https://github.com/bboehmke/docker-pebble-dev