### PR TITLE
Add libncurses5 to docker image for gdb

### DIFF
--- a/pebble-sdk/Dockerfile
+++ b/pebble-sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable
 # update system and get base packages
 RUN apt-get update && \
     apt-get install -y curl gcc git make python2.7 python2.7-dev python-dev python3-dev  python3-pip python python-virtualenv python3-virtualenv libfreetype6-dev bash-completion libsdl1.2debian \
-                       libfdt1 libpixman-1-0 libglib2.0-dev gawk && \
+                       libfdt1 libpixman-1-0 libglib2.0-dev gawk libncurses5 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
gdb requires libncurses5 to work